### PR TITLE
Change forge_fdf call to be Python 3 compatible

### DIFF
--- a/pdfjinja.py
+++ b/pdfjinja.py
@@ -195,7 +195,7 @@ class PdfJinja(object):
         return dt.strftime("%m/%d/%y")
 
     def exec_pdftk(self, data):
-        fdf = forge_fdf("", data.items(), [], [], [])
+        fdf = forge_fdf("", data.items(), [], [], [], checkbox_checked_name="Yes")
         args = [
             "pdftk",
             self.filename,


### PR DESCRIPTION
Hi, there's an upstream bug with fdfgen, specifically `fdf_forge` on Python 3.6. The problem is the default `checkbox_checked_name` is of type `bytes`, and this blows up later on a `startswith` call.

I will open a PR on fdfgen as well, but until that is merged this is a quick workaround.