### PR TITLE
changed xrange to range for python3 compatibility

### DIFF
--- a/pdfjinja.py
+++ b/pdfjinja.py
@@ -239,7 +239,7 @@ class PdfJinja(object):
             page.mergePage(watermark)
 
         output = PdfFileWriter()
-        pages = pages or xrange(filled.getNumPages())
+        pages = pages or range(filled.getNumPages())
         for p in pages:
             output.addPage(filled.getPage(p))
 


### PR DESCRIPTION
Using Python 3.6.7 i got the following error: 
```
  File "/Users/{user}/.virtualenvs/{virtualenv}/lib/python3.6/site-packages/pdfjinja.py", line 242, in __call__
    pages = pages or xrange(filled.getNumPages())
NameError: name 'xrange' is not defined
```

`xrange` is no longer soported for Python3. changing it to `range` does the trick